### PR TITLE
pretend 1.0.9: Rebuild for py314

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY314 : yes

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,6 +36,7 @@ about:
   license_file: LICENSE.rst
   license_family: BSD
   summary: A library for stubbing in Python
+  description: A library to make stubbing with Python easier.
   dev_url: https://github.com/alex/pretend
   doc_url: https://github.com/alex/pretend
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,25 +1,23 @@
 {% set name = "pretend" %}
 {% set version = "1.0.9" %}
-{% set sha256 = "c90eb810cde8ebb06dafcb8796f9a95228ce796531bc806e794c2f4649aa1b10" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  fn: {{ name }}-{{ version }}.tar.gz
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: {{ sha256 }}
+  sha256: c90eb810cde8ebb06dafcb8796f9a95228ce796531bc806e794c2f4649aa1b10
 
 build:
-  number: 1
+  number: 2
   script: pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vv
 
 requirements:
   host:
     - python
-    - setuptools
     - pip
+    - setuptools
     - wheel
   run:
     - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -35,7 +35,7 @@ about:
   license: BSD-3-Clause
   license_file: LICENSE.rst
   license_family: BSD
-  summary: A library for stubbing in Python
+  summary: A library for stubbing in Python 
   dev_url: https://github.com/alex/pretend
   doc_url: https://github.com/alex/pretend
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -35,7 +35,7 @@ about:
   license: BSD-3-Clause
   license_file: LICENSE.rst
   license_family: BSD
-  summary: A library for stubbing in Python 
+  summary: A library for stubbing in Python
   dev_url: https://github.com/alex/pretend
   doc_url: https://github.com/alex/pretend
 


### PR DESCRIPTION
**Destination channel:** main

### Links

- []()
- [Upstream repo](https://github.com/alex/pretend/tree/v1.0.9)
- release-notes: https://github.com/alex/pretend/releases
- release-notes-tagged: https://github.com/alex/pretend/releases/tag/v1.0.9
- requirements-tagged:
  - https://github.com/alex/pretend/blob/v1.0.9/setup.py


### Explanation of changes:

- Bump a build number to 2
- Add description
- Add `ANACONDA_ROCKET_ENABLE_PY314 : yes` to `abs.yaml`